### PR TITLE
feat : CORS 문제를 피하기 위한 스프링 시큐리티 설정

### DIFF
--- a/src/main/java/hanium/server/i_luv_book/global/config/security/SecurityConfig.java
+++ b/src/main/java/hanium/server/i_luv_book/global/config/security/SecurityConfig.java
@@ -13,6 +13,9 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.access.intercept.RequestAuthorizationContext;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 /**
  * @author Young9
@@ -40,6 +43,7 @@ public class SecurityConfig {
                 //모든 요청은 커스텀 인가 매니저를 통해 인가처리.
                 .authorizeHttpRequests(auth -> auth
                         .anyRequest().access(authorizationManager))
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .exceptionHandling(exception ->exception
@@ -50,6 +54,19 @@ public class SecurityConfig {
         return http.build();
     }
 
-    //    인가를 위한 계층적 권한 생성
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.addAllowedOrigin("http://localhost:3000");
+        configuration.addAllowedOrigin("https://ilv-web-app.vercel.app");
+        configuration.addAllowedMethod("*");
+        configuration.addAllowedHeader("*");
+        configuration.setAllowCredentials(true);
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**",configuration);
+        return source;
+    }
 
 }


### PR DESCRIPTION
스프링 시큐리티 설정에 CorsConfigurationSource를 커스텀하여 CORS 문제를 해결. 리액트 웹의 주소와 localhost에 대해 CORS를 허용함